### PR TITLE
Replace toCompletable with ignoreElement | Fix #48

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -846,7 +846,7 @@ Completable completable = db.member()
        // don't close the connection, just hand it back to the pool
        // and don't use this member again!
        member.checkin();
-     }).toCompletable();
+     }).ignoreElements();
 ```
 
 == Logging

--- a/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/Database.java
+++ b/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/Database.java
@@ -289,7 +289,7 @@ public final class Database implements AutoCloseable {
             } finally {
                 member.checkin();
             }
-        }).toCompletable();
+        }).ignoreElement();
     }
 
 }

--- a/rxjava2-pool/src/test/java/org/davidmoten/rx/pool/NonBlockingPoolTest.java
+++ b/rxjava2-pool/src/test/java/org/davidmoten/rx/pool/NonBlockingPoolTest.java
@@ -490,7 +490,7 @@ public class NonBlockingPoolTest {
                         .doOnSuccess((Member<Integer> m) -> {
                             checkouts.incrementAndGet();
                             m.checkin();
-                        }).toCompletable()) //
+                        }).ignoreElement()) //
                 .blockingGet(60, TimeUnit.SECONDS);
         assertNull(result);
     }


### PR DESCRIPTION
http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#toCompletable--

The document suggests using http://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#ignoreElement-- in place of the deprecated function. I see that both have similar behaviour and can *ignoreElement()* can be used to convert the *Single* to a *Completable*.

Please review.