### PR TITLE
Added query timeout support

### DIFF
--- a/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/Select.java
+++ b/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/Select.java
@@ -25,27 +25,27 @@ final class Select {
     private static final Logger log = LoggerFactory.getLogger(Select.class);
 
     static <T> Flowable<T> create(Single<Connection> connections,
-            Flowable<List<Object>> parameterGroups, String sql, int fetchSize,
-            Function<? super ResultSet, ? extends T> mapper, boolean eagerDispose) {
+                                  Flowable<List<Object>> parameterGroups, String sql, int fetchSize,
+                                  Function<? super ResultSet, ? extends T> mapper, boolean eagerDispose, int queryTimeoutSec) {
         return connections //
                 .toFlowable() //
-                .flatMap(con -> create(con, sql, parameterGroups, fetchSize, mapper, eagerDispose));
+                .flatMap(con -> create(con, sql, parameterGroups, fetchSize, mapper, eagerDispose, queryTimeoutSec));
     }
 
     static <T> Flowable<T> create(Connection con, String sql,
-            Flowable<List<Object>> parameterGroups, int fetchSize,
-            Function<? super ResultSet, T> mapper, boolean eagerDispose) {
+                                  Flowable<List<Object>> parameterGroups, int fetchSize,
+                                  Function<? super ResultSet, T> mapper, boolean eagerDispose, int queryTimeoutSec) {
         log.debug("Select.create called with con={}", con);
-        Callable<NamedPreparedStatement> initialState = () -> Util.prepare(con, fetchSize, sql);
+        Callable<NamedPreparedStatement> initialState = () -> Util.prepare(con, fetchSize, sql, queryTimeoutSec);
         Function<NamedPreparedStatement, Flowable<T>> observableFactory = ps -> parameterGroups
-                .flatMap(parameters -> create(ps.ps, parameters, mapper, ps.names, sql, fetchSize),
+                .flatMap(parameters -> create(ps.ps, parameters, mapper, ps.names, sql, fetchSize, queryTimeoutSec),
                         true, 1);
         Consumer<NamedPreparedStatement> disposer = Util::closePreparedStatementAndConnection;
         return Flowable.using(initialState, observableFactory, disposer, eagerDispose);
     }
 
     private static <T> Flowable<? extends T> create(PreparedStatement ps, List<Object> parameters,
-            Function<? super ResultSet, T> mapper, List<String> names, String sql, int fetchSize) {
+                                                    Function<? super ResultSet, T> mapper, List<String> names, String sql, int fetchSize, int queryTimeoutSec) {
         log.debug("parameters={}", parameters);
         log.debug("names={}", names);
 
@@ -56,7 +56,7 @@ final class Select {
             if (hasCollection) {
                 // create a new prepared statement with the collection ? substituted with
                 // ?s to match the size of the collection parameter
-                ps2 = Util.prepare(ps.getConnection(), fetchSize, sql, params);
+                ps2 = Util.prepare(ps.getConnection(), fetchSize, sql, params, queryTimeoutSec);
                 // now wrap the rs to auto close ps2 because it is single use (the next
                 // collection parameter may have a different ordinality so we need to build
                 // a new PreparedStatement with a different number of question marks

--- a/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/TransactedSelectAutomappedBuilder.java
+++ b/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/TransactedSelectAutomappedBuilder.java
@@ -96,7 +96,8 @@ public final class TransactedSelectAutomappedBuilder<T> {
                     sb.selectBuilder.sql, //
                     sb.selectBuilder.fetchSize, //
                     Util.autoMap(sb.cls), //
-                    false) //
+                    false, //
+                    sb.selectBuilder.queryTimeoutSec) //
                     .materialize() //
                     .flatMap(n -> Tx.toTx(n, connection.get(), db)) //
                     .doOnNext(tx -> {

--- a/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/TransactedSelectBuilder.java
+++ b/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/TransactedSelectBuilder.java
@@ -105,7 +105,8 @@ public final class TransactedSelectBuilder implements DependsOn<TransactedSelect
                     sb.sql, //
                     sb.fetchSize, //
                     mapper, //
-                    false) //
+                    false, //
+                    sb.queryTimeoutSec) //
                     .materialize() //
                     .flatMap(n -> Tx.toTx(n, connection.get(), db)) //
                     .doOnNext(tx -> {

--- a/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/TransactedUpdateBuilder.java
+++ b/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/TransactedUpdateBuilder.java
@@ -137,7 +137,8 @@ public final class TransactedUpdateBuilder implements DependsOn<TransactedUpdate
                             ub.parameterGroupsToFlowable(), //
                             ub.sql, //
                             ub.batchSize, //
-                            false) //
+                            false, //
+                            ub.queryTimeoutSec) //
                             .flatMap(n -> Tx.toTx(n, connection.get(), db)) //
                             .doOnNext(tx -> {
                                 t[0] = ((TxImpl<Integer>) tx);

--- a/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/UpdateBuilder.java
+++ b/rxjava2-jdbc/src/main/java/org/davidmoten/rx/jdbc/UpdateBuilder.java
@@ -20,6 +20,7 @@ public final class UpdateBuilder extends ParametersBuilder<UpdateBuilder> implem
     private final Database db;
     Flowable<?> dependsOn;
     int batchSize = DEFAULT_BATCH_SIZE;
+    int queryTimeoutSec = Util.QUERY_TIMEOUT_NOT_SET;
 
     UpdateBuilder(String sql, Single<Connection> connections, Database db) {
         super(sql);
@@ -40,6 +41,12 @@ public final class UpdateBuilder extends ParametersBuilder<UpdateBuilder> implem
         return this;
     }
 
+    public UpdateBuilder queryTimeoutSec(int queryTimeoutSec) {
+        Preconditions.checkArgument(queryTimeoutSec >= 0);
+        this.queryTimeoutSec = queryTimeoutSec;
+        return this;
+    }
+
     /**
      * Returns a builder used to specify how to process the generated keys
      * {@link ResultSet}. Not all jdbc drivers support this functionality and
@@ -56,7 +63,7 @@ public final class UpdateBuilder extends ParametersBuilder<UpdateBuilder> implem
 
     public Flowable<Integer> counts() {
         return startWithDependency(
-                Update.create(connections, super.parameterGroupsToFlowable(), sql, batchSize, true).dematerialize());
+                Update.create(connections, super.parameterGroupsToFlowable(), sql, batchSize, true, queryTimeoutSec).dematerialize());
     }
 
     <T> Flowable<T> startWithDependency(@Nonnull Flowable<T> f) {


### PR DESCRIPTION
I was missing the ability to set query timeout.
All that was needed is to propagate the timeout setting to the jdbc PreparedStatement interface which supports this setting.