### PR TITLE
Add automap support for concrete classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <rxjava.version>2.2.17</rxjava.version>
         <checkstyle.version>2.17</checkstyle.version>
         <findbugs.version>3.0.5</findbugs.version>
-        <javadoc.version>3.0.0</javadoc.version>
+        <javadoc.version>3.2.0</javadoc.version>
         <pmd.version>3.8</pmd.version>
         <jdepend.version>2.0</jdepend.version>
         <javancss.version>2.1</javancss.version>

--- a/rxjava2-jdbc/src/test/java/org/davidmoten/rx/jdbc/UtilTest.java
+++ b/rxjava2-jdbc/src/test/java/org/davidmoten/rx/jdbc/UtilTest.java
@@ -1,5 +1,7 @@
 package org.davidmoten.rx.jdbc;
 
+import static org.davidmoten.rx.jdbc.fixtures.Fixtures.listOf;
+import static org.davidmoten.rx.jdbc.fixtures.Fixtures.mockPersonResultSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -11,17 +13,14 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
-import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import java.sql.*;
 import java.time.Instant;
 import java.util.List;
 
 import javax.sql.DataSource;
 
 import org.davidmoten.rx.jdbc.exceptions.SQLRuntimeException;
+import org.davidmoten.rx.jdbc.fixtures.Person;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -74,6 +73,24 @@ public class UtilTest {
     @Test
     public void testAutomapDateToString() {
         assertEquals(100L, ((java.sql.Date) Util.autoMap(new java.sql.Date(100), String.class)).getTime());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testClassAutoMap() throws SQLException {
+        ResultSetMapper<Person> mapper = Util.autoMap(Person.class);
+
+        ResultSet mockedResultSet = mockPersonResultSet(listOf("John", "Doe"));
+        Person mappedPerson = mapper.apply(mockedResultSet);
+
+        assertEquals(mappedPerson, new Person("John", "Doe"));
+
+        mockedResultSet = mockPersonResultSet(listOf("John", null));
+        mappedPerson = mapper.apply(mockedResultSet);
+
+        assertEquals(mappedPerson, new Person("John", null));
+
+        mockedResultSet = mockPersonResultSet(listOf("John", "Doe", "Test"));
+        mapper.apply(mockedResultSet);
     }
 
     @Test

--- a/rxjava2-jdbc/src/test/java/org/davidmoten/rx/jdbc/fixtures/Fixtures.java
+++ b/rxjava2-jdbc/src/test/java/org/davidmoten/rx/jdbc/fixtures/Fixtures.java
@@ -1,0 +1,37 @@
+package org.davidmoten.rx.jdbc.fixtures;
+
+import com.github.davidmoten.guavamini.Lists;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class Fixtures {
+    public static List<String> listOf(String ... params) {
+        return Lists.newArrayList(params);
+    }
+
+    public static ResultSet mockPersonResultSet(List<String> parameterValues) throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        ResultSetMetaData rsMeta = mock(ResultSetMetaData.class);
+
+        when(rsMeta.getColumnCount()).thenReturn(parameterValues.size());
+
+        for(int i = 0; i < parameterValues.size(); i++) {
+            when(rsMeta.getColumnType(i)).thenReturn(Types.VARCHAR);
+        }
+
+        when(rs.getMetaData()).thenReturn(rsMeta);
+
+        for(int i = 0; i < parameterValues.size(); i++) {
+            when(rs.getObject(i + 1)).thenReturn(parameterValues.get(i));
+        }
+
+        return rs;
+    }
+}

--- a/rxjava2-jdbc/src/test/java/org/davidmoten/rx/jdbc/fixtures/Person.java
+++ b/rxjava2-jdbc/src/test/java/org/davidmoten/rx/jdbc/fixtures/Person.java
@@ -1,0 +1,27 @@
+package org.davidmoten.rx.jdbc.fixtures;
+
+import java.util.Objects;
+
+public class Person {
+    public final String firstName;
+    public final String lastName;
+
+    public Person(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Person test = (Person) o;
+        return Objects.equals(firstName, test.firstName) &&
+                Objects.equals(lastName, test.lastName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName);
+    }
+}


### PR DESCRIPTION
Hello, @davidmoten!

Thank you for your work on this project, it's very useful and it definitely helps a lot of developers. 

I noticed that auto-map support for concrete classes was dropped on this project (comparing to `rxjava-jdbc` project), for the reasons you mentioned on issue https://github.com/davidmoten/rxjava2-jdbc/issues/15, which I completely understand.

However, it is an important feature that is really needed, mostly for the ones who migrate from `rxjava-jdbc`, which need to update their models to be compatible with this new project.

In alignment to your expressed intention (in the above mentioned issue) to add back that functionality, I decided to take some time to explore the code and see if I can add it back on (and this PR is the result of that effort).

I mainly took the code from the `rxjava-jdbc` and I integrated it here, as best as I could, and I also added a small unit test to see if it works as expected. 

I updated the javadoc version because I hit [that](https://stackoverflow.com/questions/49460751/execution-attach-javadocs-of-goal-org-apache-maven-pluginsmaven-javadoc-plugin) issue when I tried to build the project on my machine.

Thank you and let me know what you think about it!