### PR TITLE
rxjava2-pool - resolve MemberSingle race conditions - move observers modification to the drain loop

### DIFF
--- a/rxjava2-pool/src/test/java/org/davidmoten/rx/pool/NonBlockingPoolConcurrencyTest.java
+++ b/rxjava2-pool/src/test/java/org/davidmoten/rx/pool/NonBlockingPoolConcurrencyTest.java
@@ -35,7 +35,7 @@ public class NonBlockingPoolConcurrencyTest {
                     .doOnNext(x -> c[0]++) //
                     // have to keep the observeOn buffer small so members don't get buffered
                     // and not checked in
-                    .observeOn(Schedulers.from(Executors.newFixedThreadPool(1)), false, 1) //
+                    .observeOn(Schedulers.from(Executors.newFixedThreadPool(poolSize)), false, 1) //
                     .doOnNext(member -> member.checkin()) //
                     .timeout(10, TimeUnit.SECONDS) //
                     .doOnError(e -> {


### PR DESCRIPTION
Concurrency unit testing revealed occasional failures that were due to race conditions with modification of observers outside the MemberSingle.drain loop. To resolve this all modification actions to the observers happen via queues that are polled in the drain loop.

With the simplifications and extra tests, coverage has increased a bit. Unlikely to put in the hard tedious yards to knock off the rest.

This is a fix backported from https://github.com/davidmoten/rxjava3-pool.