### PR TITLE
Fix bug with application of max idle time

### DIFF
--- a/rxjava2-pool/src/main/java/org/davidmoten/rx/internal/LifoQueue.java
+++ b/rxjava2-pool/src/main/java/org/davidmoten/rx/internal/LifoQueue.java
@@ -2,11 +2,14 @@ package org.davidmoten.rx.internal;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.Nullable;
+
 public final class LifoQueue<T> {
 
     private final AtomicReference<Node<T>> head = new AtomicReference<>();
 
-    public void offer(T t) {
+    public void offer(@NonNull T t) {
         while (true) {
             Node<T> a = head.get();
             Node<T> b = new Node<>(t, a);
@@ -36,8 +39,8 @@ public final class LifoQueue<T> {
     }
 
     static final class Node<T> {
-        final T value;
-        final Node<T> next;
+        final @NonNull T value;
+        final @Nullable Node<T> next;
 
         Node(T value, Node<T> next) {
             this.value = value;

--- a/rxjava2-pool/src/main/java/org/davidmoten/rx/internal/LifoQueue.java
+++ b/rxjava2-pool/src/main/java/org/davidmoten/rx/internal/LifoQueue.java
@@ -1,0 +1,48 @@
+package org.davidmoten.rx.internal;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class LifoQueue<T> {
+
+    private final AtomicReference<Node<T>> head = new AtomicReference<>();
+
+    public void offer(T t) {
+        while (true) {
+            Node<T> a = head.get();
+            Node<T> b = new Node<>(t, a);
+            if (head.compareAndSet(a, b)) {
+                return;
+            }
+        }
+    }
+
+    public T poll() {
+        Node<T> a = head.get();
+        if (a == null) {
+            return null;
+        } else {
+            while (true) {
+                if (head.compareAndSet(a, a.next)) {
+                    return a.value;
+                } else {
+                    a = head.get();
+                }
+            }
+        }
+    }
+    
+    public void clear() {
+        head.set(null);
+    }
+
+    static final class Node<T> {
+        final T value;
+        final Node<T> next;
+
+        Node(T value, Node<T> next) {
+            this.value = value;
+            this.next = next;
+        }
+    }
+
+}

--- a/rxjava2-pool/src/main/java/org/davidmoten/rx/internal/LifoQueue.java
+++ b/rxjava2-pool/src/main/java/org/davidmoten/rx/internal/LifoQueue.java
@@ -5,6 +5,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.annotations.Nullable;
 
+/**
+ * Thread-safe Last-In-First-Out queue. Current usage is multi-producer, single
+ * consumer but LIFO use case doesn't seem to offer opportunity for performance
+ * enhancements like the MpscLinkedQueue does for FIFO use case.
+ *
+ * @param <T> queued item type
+ */
 public final class LifoQueue<T> {
 
     private final AtomicReference<Node<T>> head = new AtomicReference<>();
@@ -19,7 +26,7 @@ public final class LifoQueue<T> {
         }
     }
 
-    public T poll() {
+    public @Nullable T poll() {
         Node<T> a = head.get();
         if (a == null) {
             return null;
@@ -33,7 +40,7 @@ public final class LifoQueue<T> {
             }
         }
     }
-    
+
     public void clear() {
         head.set(null);
     }

--- a/rxjava2-pool/src/main/java/org/davidmoten/rx/pool/MemberSingle.java
+++ b/rxjava2-pool/src/main/java/org/davidmoten/rx/pool/MemberSingle.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
+import org.davidmoten.rx.internal.LifoQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ final class MemberSingle<T> extends Single<Member<T>> implements Closeable {
     // toBeRemoved queue
     private final MemberSingleObserver<T> removeAll;
 
-    private final SimplePlainQueue<DecoratingMember<T>> initializedAvailable;
+    private final LifoQueue<DecoratingMember<T>> initializedAvailable;
     private final SimplePlainQueue<DecoratingMember<T>> notInitialized;
     private final SimplePlainQueue<DecoratingMember<T>> toBeReleased;
     private final SimplePlainQueue<DecoratingMember<T>> toBeChecked;
@@ -63,7 +64,7 @@ final class MemberSingle<T> extends Single<Member<T>> implements Closeable {
     MemberSingle(NonBlockingPool<T> pool) {
         Preconditions.checkNotNull(pool);
         this.notInitialized = new MpscLinkedQueue<>();
-        this.initializedAvailable = new MpscLinkedQueue<>();
+        this.initializedAvailable = new LifoQueue<>();
         this.toBeReleased = new MpscLinkedQueue<>();
         this.toBeChecked = new MpscLinkedQueue<>();
         this.toBeAdded = new MpscLinkedQueue<>();

--- a/rxjava2-pool/src/test/java/org/davidmoten/rx/internal/LifoQueueTest.java
+++ b/rxjava2-pool/src/test/java/org/davidmoten/rx/internal/LifoQueueTest.java
@@ -1,0 +1,20 @@
+package org.davidmoten.rx.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class LifoQueueTest {
+    
+    @Test
+    public void testIsLifo() {
+        LifoQueue<Integer> q = new LifoQueue<>();
+        q.offer(1);
+        q.offer(2);
+        assertEquals(2, (int) q.poll());
+        assertEquals(1, (int) q.poll());
+        assertNull(q.poll());
+    }
+
+}

--- a/rxjava2-pool/src/test/java/org/davidmoten/rx/internal/LifoQueueTest.java
+++ b/rxjava2-pool/src/test/java/org/davidmoten/rx/internal/LifoQueueTest.java
@@ -16,5 +16,14 @@ public class LifoQueueTest {
         assertEquals(1, (int) q.poll());
         assertNull(q.poll());
     }
+    
+    @Test
+    public void testClear() {
+        LifoQueue<Integer> q = new LifoQueue<>();
+        q.offer(1);
+        q.offer(2);
+        q.clear();
+        assertNull(q.poll());
+    }
 
 }

--- a/rxjava2-pool/src/test/java/org/davidmoten/rx/pool/NonBlockingPoolTest.java
+++ b/rxjava2-pool/src/test/java/org/davidmoten/rx/pool/NonBlockingPoolTest.java
@@ -240,20 +240,21 @@ public class NonBlockingPoolTest {
     }
 
     @Test
-    public void testConnectionPoolRecylesLastInFirstOut() throws SQLException {
+    public void testConnectionPoolRecylesLastInFirstOut() throws Exception {
         AtomicInteger count = new AtomicInteger();
-        Pool<Integer> pool = NonBlockingPool //
+        try (Pool<Integer> pool = NonBlockingPool //
                 .factory(() -> count.incrementAndGet()) //
                 .healthCheck(n -> true) //
                 .maxSize(4) //
                 .maxIdleTime(1, TimeUnit.MINUTES) //
-                .build();
-        Member<Integer> m1 = pool.member().blockingGet();
-        Member<Integer> m2 = pool.member().blockingGet();
-        m1.checkin();
-        m2.checkin();
-        Member<Integer> m3 = pool.member().blockingGet();
-        assertTrue(m2 == m3);
+                .build()) {
+            Member<Integer> m1 = pool.member().blockingGet();
+            Member<Integer> m2 = pool.member().blockingGet();
+            m1.checkin();
+            m2.checkin();
+            Member<Integer> m3 = pool.member().blockingGet();
+            assertTrue(m2 == m3);
+        }
     }
     
     @Test


### PR DESCRIPTION
As discussed in #41, if concurrent actions have ensured that the pool has N connections (N > 1) and there are N single threaded actions using the pool before max idle time is reached then despite the fact that only 1 connection has been used since the pool expanded to N no connections are timed out and released.

This was because a FIFO queue was used to gather checked-in connections which brought about round-robin behaviour. The fix is to switch to using a LIFO queue.